### PR TITLE
Use wxpython>=4.2.5

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -221,11 +221,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/28/d06dca77a3e577d0efcdb5efaaf8a6d64829503b8f4d85c7f10eb1f02c1b/wxmplot-2025.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/d9/4451392d3d6ba45aa23aa77a6f1a9970b43351b956bf61e10fd513a1dc38/wxPython-4.2.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/f1/6e/501e11ac145ec679955c431b6aa9554b6c0f7b90b65fa9ecce6f364b4650/wxutils-0.3.5-py3-none-any.whl
-      - pypi: git+https://github.com/NSLS-II-ISS/xas#9158e6eaa8ac8691c71506d2ddaa6f63c406c12a
+      - pypi: git+https://github.com/NSLS-II-ISS/xas#20a466cb46a30bd6aa87102f6020a3a6f5ca82f4
       - pypi: https://files.pythonhosted.org/packages/38/8b/7ec325b4e9e78beefc2d025b01ee8a2fde771ef7c957c3bff99b9e1fbffa/xraydb-4.5.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/05/48c990374cbd4769c6d2488c6f982caf568c0b2c96703d310fd24928c941/xraylarch-2025.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -472,11 +472,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/28/d06dca77a3e577d0efcdb5efaaf8a6d64829503b8f4d85c7f10eb1f02c1b/wxmplot-2025.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/d9/4451392d3d6ba45aa23aa77a6f1a9970b43351b956bf61e10fd513a1dc38/wxPython-4.2.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/f1/6e/501e11ac145ec679955c431b6aa9554b6c0f7b90b65fa9ecce6f364b4650/wxutils-0.3.5-py3-none-any.whl
-      - pypi: git+https://github.com/NSLS-II-ISS/xas#9158e6eaa8ac8691c71506d2ddaa6f63c406c12a
+      - pypi: git+https://github.com/NSLS-II-ISS/xas#20a466cb46a30bd6aa87102f6020a3a6f5ca82f4
       - pypi: https://files.pythonhosted.org/packages/38/8b/7ec325b4e9e78beefc2d025b01ee8a2fde771ef7c957c3bff99b9e1fbffa/xraydb-4.5.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/05/48c990374cbd4769c6d2488c6f982caf568c0b2c96703d310fd24928c941/xraylarch-2025.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -4073,9 +4073,9 @@ packages:
   - coverage ; extra == 'test'
   - wxutils[dev,doc,test] ; extra == 'all'
   requires_python: '>=3.9'
-- pypi: git+https://github.com/NSLS-II-ISS/xas#9158e6eaa8ac8691c71506d2ddaa6f63c406c12a
+- pypi: git+https://github.com/NSLS-II-ISS/xas#20a466cb46a30bd6aa87102f6020a3a6f5ca82f4
   name: xas
-  version: 0.0.1.post408+g9158e6e
+  version: 0.0.1.post415+g20a466c
 - pypi: https://files.pythonhosted.org/packages/38/8b/7ec325b4e9e78beefc2d025b01ee8a2fde771ef7c957c3bff99b9e1fbffa/xraydb-4.5.8-py3-none-any.whl
   name: xraydb
   version: 4.5.8
@@ -4166,13 +4166,14 @@ packages:
   - xraylarch[jupyter,wxgui] ; extra == 'larix'
   - xraylarch[dev,doc,epics,jupyter,qtgui,wxgui] ; extra == 'all'
   requires_python: '>=3.9'
-- pypi: .
+- pypi: ./
   name: xviewlite
-  version: 0.1.dev223+gbcba236a5.d20250819
-  sha256: 99eb6f07982bf34805c4e068ce4f23a5b3d7a68fa4ae9d28174a0d8bae6ca6dc
+  version: 0.1.dev226+gd4d0a30c2.d20260312
+  sha256: e573ea10d5fdfcb53f2104425342e5c467c909e8b19a288d82afbdbee5921ab4
   requires_dist:
   - pyqt5
   - pyqtgraph
+  - setuptools<81
   - xas @ git+https://github.com/NSLS-II-ISS/xas
   - xraylarch[larix]
   - codecov ; extra == 'dev'

--- a/pixi.lock
+++ b/pixi.lock
@@ -219,7 +219,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/28/d06dca77a3e577d0efcdb5efaaf8a6d64829503b8f4d85c7f10eb1f02c1b/wxmplot-2025.1.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4c/d9/4451392d3d6ba45aa23aa77a6f1a9970b43351b956bf61e10fd513a1dc38/wxPython-4.2.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz
       - pypi: https://files.pythonhosted.org/packages/f1/6e/501e11ac145ec679955c431b6aa9554b6c0f7b90b65fa9ecce6f364b4650/wxutils-0.3.5-py3-none-any.whl
       - pypi: git+https://github.com/NSLS-II-ISS/xas#20a466cb46a30bd6aa87102f6020a3a6f5ca82f4
       - pypi: https://files.pythonhosted.org/packages/38/8b/7ec325b4e9e78beefc2d025b01ee8a2fde771ef7c957c3bff99b9e1fbffa/xraydb-4.5.8-py3-none-any.whl
@@ -470,7 +470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/28/d06dca77a3e577d0efcdb5efaaf8a6d64829503b8f4d85c7f10eb1f02c1b/wxmplot-2025.1.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4c/d9/4451392d3d6ba45aa23aa77a6f1a9970b43351b956bf61e10fd513a1dc38/wxPython-4.2.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz
       - pypi: https://files.pythonhosted.org/packages/f1/6e/501e11ac145ec679955c431b6aa9554b6c0f7b90b65fa9ecce6f364b4650/wxutils-0.3.5-py3-none-any.whl
       - pypi: git+https://github.com/NSLS-II-ISS/xas#20a466cb46a30bd6aa87102f6020a3a6f5ca82f4
       - pypi: https://files.pythonhosted.org/packages/38/8b/7ec325b4e9e78beefc2d025b01ee8a2fde771ef7c957c3bff99b9e1fbffa/xraydb-4.5.8-py3-none-any.whl
@@ -4051,14 +4051,14 @@ packages:
   - coverage ; extra == 'test'
   - wxmplotls[dev,doc,test] ; extra == 'all'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/4c/d9/4451392d3d6ba45aa23aa77a6f1a9970b43351b956bf61e10fd513a1dc38/wxPython-4.2.3.tar.gz
+- pypi: https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz
   name: wxpython
-  version: 4.2.3
-  sha256: 20d6e0c927e27ced85643719bd63e9f7fd501df6e9a8aab1489b039897fd7c01
+  version: 4.2.5
+  sha256: 44e836d1bccd99c38790bb034b6ecf70d9060f6734320560f7c4b0d006144793
   requires_dist:
   - numpy ; python_full_version >= '3.0' and python_full_version < '3.12'
   - typing-extensions ; python_full_version < '3.11'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f1/6e/501e11ac145ec679955c431b6aa9554b6c0f7b90b65fa9ecce6f364b4650/wxutils-0.3.5-py3-none-any.whl
   name: wxutils
   version: 0.3.5
@@ -4168,12 +4168,12 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: xviewlite
-  version: 0.1.dev226+gd4d0a30c2.d20260312
-  sha256: e573ea10d5fdfcb53f2104425342e5c467c909e8b19a288d82afbdbee5921ab4
+  version: 0.1.dev227+gc5edd9914.d20260316
+  sha256: 4179f3adec7c6c5436334545ae6fa235d997dcfc2b96e472d8aeb951dabfb30a
   requires_dist:
   - pyqt5
   - pyqtgraph
-  - setuptools<81
+  - wxpython>=4.2.5
   - xas @ git+https://github.com/NSLS-II-ISS/xas
   - xraylarch[larix]
   - codecov ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.10"
 dependencies = [
     "PyQt5",
     "pyqtgraph",
-    "setuptools<81",
+    "wxpython>=4.2.5",
     "xraylarch[larix]",
     "xas @ git+https://github.com/NSLS-II-ISS/xas",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.10"
 dependencies = [
     "PyQt5",
     "pyqtgraph",
+    "setuptools<81",
     "xraylarch[larix]",
     "xas @ git+https://github.com/NSLS-II-ISS/xas",
 ]


### PR DESCRIPTION
There's some dependency issues with the xviewlite pixi environment related to breaking changes introduced in setuptools version 81. This PR pins wxpython to the current latest version (4.2.5) fixing the dependency issues ([related](https://discuss.wxpython.org/t/typeerror-copy-file-takes-from-2-to-7-positional-arguments-but-8-were-given/40408/11)).